### PR TITLE
Various fixes for client generation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,21 +4,9 @@
         "Dockerfile*": "dockerfile",
         "iris.script": "objectscript"
       },
-    "objectscript.conn" :{
-      "active": true,
-      "ns": "IRISAPP",
-      "username": "_SYSTEM",
-      "password": "SYS",
-      "docker-compose": {
-        "service": "iris",
-        "internalPort": 52773
-      },
-      "links": {
-        "UnitTest Portal": "${serverUrl}/csp/sys/%25UnitTest.Portal.Home.cls?$NAMESPACE=IRISAPP",
-        "Production Portal": "${serverUrl}/csp/irisapp/EnsPortal.ProductionConfig.zen?$NAMESPACE=IRISAPP&$NAMESPACE=IRISAPP&",
-        "OpenAPI Suite UI": "${serverUrl}/openapisuite/ui/index.csp?"
+      "objectscript.conn": {
+        "server": "samples-fhir-docker",
+        "ns": "NUTS",
+        "active": true
       }
-    },
-    "workbench.colorTheme": "InterSystems Default Dark"
-
 }

--- a/src/Grongier/OpenApi/DefinitionV3.cls
+++ b/src/Grongier/OpenApi/DefinitionV3.cls
@@ -20,12 +20,7 @@ Property allowPropertyOverride As %Boolean [ InitialExpression = {$$$YES} ];
 
 Property generateInLineModel As %Boolean [ InitialExpression = {$$$NO} ];
 
-Method %OnNew(
-	specification As %DynamicObject,
-	package As %String,
-	super As %String,
-	compile As %Boolean,
-	flags As %String) As %Status
+Method %OnNew(specification As %DynamicObject, package As %String, super As %String, compile As %Boolean, flags As %String) As %Status
 {
     Set ..spec = specification, ..package = package
 
@@ -87,9 +82,7 @@ Method GenerateClasses() As %Status
     Quit sc
 }
 
-Method GenerateClassModel(
-	schema As %DynamicObject,
-	className As %String) As %Status
+Method GenerateClassModel(schema As %DynamicObject, className As %String) As %Status
 {
     Set sc = $$$OK, requiredArray = []
 
@@ -111,9 +104,7 @@ Method GenerateClassModel(
     Quit sc
 }
 
-Method GenerateProperties(
-	classDef As %Dictionary.ClassDefinition,
-	properties As %DynamicObject) As %Status
+Method GenerateProperties(classDef As %Dictionary.ClassDefinition, properties As %DynamicObject) As %Status
 {
     Set sc = $$$OK
 
@@ -191,7 +182,7 @@ Method GenerateProperties(
     Quit sc
 
 AdditionalPropertySettings
-    Set propDef.Description = $Select(pObj.description[$Char(13,10):$Replace(pObj.description,$Char(13,10),$Char(13,10)_"/// "),1:$Replace(pObj.description,$Char(10),$Char(10)_"/// "))
+    Set propDef.Description = $REPLACE($ZSTRIP($ZSTRIP(pObj.description, "*", $Char(13)), "<>CW"), $Char(10), $Char(10) _ "/// ")
     Do:pObj.maxLength'="" propDef.Parameters.SetAt(pObj.maxLength,"MAXLEN")        
     Do:pObj.minLength'="" propDef.Parameters.SetAt(pObj.minLength,"MINLEN")        
     Do:pObj.minimum'="" propDef.Parameters.SetAt(pObj.minimum,"MINVAL")        
@@ -223,9 +214,7 @@ XMLParameters
     Quit
 }
 
-Method ManageAllOf(
-	classDef As %Dictionary.ClassDefinition,
-	schema As %DynamicObject) As %Status
+Method ManageAllOf(classDef As %Dictionary.ClassDefinition, schema As %DynamicObject) As %Status
 {
     Set sc = $$$OK, superClasses = ""
     
@@ -254,9 +243,7 @@ Method ManageAllOf(
     Quit sc
 }
 
-Method ManageRequiredProperties(
-	classDef As %Dictionary.ClassDefinition,
-	requiredArray As %DynamicArray) As %Status
+Method ManageRequiredProperties(classDef As %Dictionary.ClassDefinition, requiredArray As %DynamicArray) As %Status
 {
     Set sc = $$$OK
 
@@ -372,10 +359,7 @@ parametersObject
     Quit
 }
 
-ClassMethod log(
-	msg As %String,
-	nl As %Boolean = {$$$YES},
-	dtOnNL As %Boolean = {$$$YES})
+ClassMethod log(msg As %String, nl As %Boolean = {$$$YES}, dtOnNL As %Boolean = {$$$YES})
 {
     Quit:$Get(%zverbose)=0
 
@@ -386,9 +370,7 @@ ClassMethod log(
     Quit
 }
 
-ClassMethod GetObjectScriptType(
-	oaType As %DynamicObject,
-	format As %String = "") As %String
+ClassMethod GetObjectScriptType(oaType As %DynamicObject, format As %String = "") As %String
 {
 
     Quit:oaType="" "%VarString"
@@ -416,10 +398,7 @@ ClassMethod GetObjectScriptType(
     Quit $Get(table(oaType, format), $Get(table(oaType), "%VarString" ))
 }
 
-Method GetObjectByRef(
-	reference As %String,
-	Output name As %String,
-	Output package As %String) As %DynamicObject
+Method GetObjectByRef(reference As %String, Output name As %String, Output package As %String) As %DynamicObject
 {
     ; required : Do ##class(dc.openapi.common.Utils).SetTempData("model.package", ..package)
     Quit ##class(dc.openapi.common.Utils).GetObjectByRef(..spec, reference, .name, .package)
@@ -431,9 +410,7 @@ ClassMethod GetSpecForPackage(package As %String) As %DynamicObject [ CodeMode =
 ##class(dc.openapi.common.Utils).GetSpecForPackage(package)
 }
 
-ClassMethod CreateClassDefInstance(
-	className As %String,
-	Output classDef As %Dictionary.ClassDefinition = "") As %Dictionary.ClassDefinition
+ClassMethod CreateClassDefInstance(className As %String, Output classDef As %Dictionary.ClassDefinition = "") As %Dictionary.ClassDefinition
 {
     If $$$defClassDefined(className) {
         Set sc = $$Delete^%apiOBJ(className,"-d")
@@ -452,11 +429,7 @@ ClassMethod CreateClassDefInstance(
     Quit $$$OK
 }
 
-Method CommonSchemaProcess(
-	classDef As %Dictionary.ClassDefinition,
-	propDef As %Dictionary.PropertyDefinition,
-	schema As %DynamicObject,
-	name As %String) As %Status
+Method CommonSchemaProcess(classDef As %Dictionary.ClassDefinition, propDef As %Dictionary.PropertyDefinition, schema As %DynamicObject, name As %String) As %Status
 {
     Set sc = $$$OK
 
@@ -509,9 +482,7 @@ Method CommonSchemaProcess(
     Quit sc
 }
 
-ClassMethod FindPropertyName(
-	classDefinition As %Dictionary.ClassDefinition,
-	propertyName As %String) As %Dictionary.PropertyDefinition
+ClassMethod FindPropertyName(classDefinition As %Dictionary.ClassDefinition, propertyName As %String) As %Dictionary.PropertyDefinition
 {
     #dim property As %Dictionary.PropertyDefinition
     Set key = ""
@@ -527,11 +498,7 @@ ClassMethod FindPropertyName(
     Return ""
 }
 
-ClassMethod GetClsNameForAnonymObject(
-	path As %String = "",
-	method As %String = "",
-	name As %String = "",
-	contentType As %String = "") As %String
+ClassMethod GetClsNameForAnonymObject(path As %String = "", method As %String = "", name As %String = "", contentType As %String = "") As %String
 {
     Quit "Z"_name _ $ZCRC(path_method_name_contentType,0)
 }

--- a/src/dc/openapi/client/HttpClientGenerator.cls
+++ b/src/dc/openapi/client/HttpClientGenerator.cls
@@ -18,9 +18,7 @@ Property superGenericResponse As %String [ InitialExpression = "%RegisteredObjec
 
 Property superModel As %String [ InitialExpression = "%JSON.Adaptor,%XML.Adaptor,%RegisteredObject" ];
 
-Method %OnNew(
-	specification As %DynamicObject,
-	application As %String) As %Status
+Method %OnNew(specification As %DynamicObject, application As %String) As %Status
 {
     Set ..spec = specification
     Set ..application = application
@@ -80,11 +78,7 @@ Method GenerateModels() As %Status
     Quit sc
 }
 
-Method GenerateLoadHttpRequestObject(
-	path As %String,
-	pathItem As %DynamicObject,
-	method As %String,
-	operation As %DynamicObject) As %Status
+Method GenerateLoadHttpRequestObject(path As %String, pathItem As %DynamicObject, method As %String, operation As %DynamicObject) As %Status
 {
     #dim propDef As %Dictionary.PropertyDefinition
     Set sc = $$$OK
@@ -357,11 +351,7 @@ Method httpClientClass() As %Status [ Private ]
 }
 
 /// Generate method that execute the http request for a service into the HttpClient class
-Method GenerateMethodExecutor(
-	path As %String,
-	pathItem As %DynamicObject,
-	method As %String,
-	operation As %DynamicObject) As %Status
+Method GenerateMethodExecutor(path As %String, pathItem As %DynamicObject, method As %String, operation As %DynamicObject) As %Status
 {
     Set sc = $$$OK
     Set classDef = ##class(%Dictionary.ClassDefinition).%OpenId(..httpClientClassName,, .sc)
@@ -391,11 +381,7 @@ Method GenerateMethodExecutor(
     Quit classDef.%Save()
 }
 
-Method GenerateResponseClass(
-	path As %String,
-	pathItem As %DynamicObject,
-	method As %String,
-	operation As %DynamicObject) As %Status
+Method GenerateResponseClass(path As %String, pathItem As %DynamicObject, method As %String, operation As %DynamicObject) As %Status
 {
     Set sc = $$$OK
 
@@ -446,9 +432,9 @@ Method GenerateResponseClass(
                     Set propertyToGen(k1, 1, "description") = $Get(propertyToGen(k1, 1, "description"))
                         _ "http status code = "_code _" content-type = " _contentType_$c(13,10)
                 } Else { ;inline array data type
-                    Set k1 = "%DynamicArray"
-                    Set propertyToGen(k1, 0) = "ResponseArray"
-                    Set propertyToGen(k1, 0, "description") = $Get(propertyToGen(k1, 0, "description"))
+                    Set k1 = ##class(Grongier.OpenApi.DefinitionV3).GetObjectScriptType(contentTypeItem.schema.items.type, contentTypeItem.schema.items.format)
+                    Set propertyToGen(k1, 1) = "ListOf" _ $$$zNormalizeClassName(k1)
+                    Set propertyToGen(k1, 1, "description") = $Get(propertyToGen(k1, 1, "description"))
                         _ "http status code = "_code _" content-type = " _contentType_$c(13,10)
                 }
             }
@@ -469,6 +455,10 @@ Method GenerateResponseClass(
             Set propDef.Type = key
             Set propDef.Description = $Get(propertyToGen(key, i, "description"))
             Set:i=1 propDef.Collection = "list"
+            if key = "%String"
+            {
+                do propDef.Parameters.SetAt("", "MAXLEN")                                
+            }
             Do:$Data(propertyToGen(key, i, "XMLNAME"),xmlName) propDef.Parameters.SetAt(xmlName, "XMLNAME")
             $$$zlog($Char(9) _ "+ Add property " _ propertyName)
             Do classDef.Properties.Insert(propDef)
@@ -481,11 +471,7 @@ Method GenerateResponseClass(
     Quit sc
 }
 
-Method GenerateLoadFromResponse(
-	path As %String,
-	pathItem As %DynamicObject,
-	method As %String,
-	operation As %DynamicObject) As %Status
+Method GenerateLoadFromResponse(path As %String, pathItem As %DynamicObject, method As %String, operation As %DynamicObject) As %Status
 {
     Set sc = $$$OK
     
@@ -560,14 +546,19 @@ Method GenerateLoadFromResponse(
                     Set ref = ##class(dc.openapi.common.Utils).GetObjectByRef(..spec, contentTypeItem.schema.items."$ref", .refName, .package)
                     Set k1 = $Select(package="":..packageModel,1:package) _ "." _ $$$zNormalizeClassName(refName)
                 }
- 
+                Else {
+                    Set refName = ##class(Grongier.OpenApi.DefinitionV3).GetObjectScriptType(contentTypeItem.schema.items.type, contentTypeItem.schema.items.format)
+                    Set k1 = "%ListOfDataTypes"
+                }
+
                 Do methodDef.Implementation.WriteLine( $Char(9) _ "If $$$LOWER($Piece(httpResponse.ContentType,"";"",1))=""" _ contentType _ """,httpResponse.StatusCode = """ _ $tr(code,"""") _ """ {")
 
                 ;If contentType = "application/json", contentTypeItem.schema.%IsDefined("items"), contentTypeItem.schema.items.type = "string" { ;inline array
-                If contentType = "application/json", 'contentTypeItem.schema.items.%IsDefined("$ref") { ;inline array
-                    Do methodDef.Implementation.WriteLine( $Char(9,9) _ "Set ..ResponseArray = [].%FromJSON(httpResponse.Data)")
-                    Do methodDef.Implementation.WriteLine( $Char(9,9) _ "Return sc")
-                } ElseIf contentType = "application/json" {
+                #; If contentType = "application/json", 'contentTypeItem.schema.items.%IsDefined("$ref") { ;inline array
+                #;     Do methodDef.Implementation.WriteLine( $Char(9,9) _ "Set ..ResponseArray = [].%FromJSON(httpResponse.Data)")
+                #;     Do methodDef.Implementation.WriteLine( $Char(9,9) _ "Return sc")
+                #; } Else
+                If contentType = "application/json" {
                     Do methodDef.Implementation.WriteLine( $Char(9,9) _ "Set array = [].%FromJSON(httpResponse.Data), iterator = array.%GetIterator()")
                     Do methodDef.Implementation.WriteLine( $Char(9,9) _ "While iterator.%GetNext(.index, .item) {")
                     Do methodDef.Implementation.WriteLine( $Char(9,9,9) _ "Set obj = ##class("_k1 _").%New()")

--- a/src/dc/openapi/client/ProductionGenerator.cls
+++ b/src/dc/openapi/client/ProductionGenerator.cls
@@ -13,9 +13,7 @@ Property productionClassName As %String [ InitialExpression = "Production" ];
 
 Property tmp As %Binary [ MultiDimensional ];
 
-Method %OnNew(
-	specification As %DynamicObject,
-	application As %String) As %Status
+Method %OnNew(specification As %DynamicObject, application As %String) As %Status
 {
     Set ..spec = specification
     Set ..application = application
@@ -40,14 +38,14 @@ Method Generate(ByRef features) As %Status
 
     Set sc = $$$ADDSC(sc, httpClientGenerator.GenerateClient(.features))
 
-    If $Get(features("noBS")) '= 1 {
-        ; Generate Business services
-        Set sc = $$$ADDSC(sc, ..IterateOnOperation("GenerateBusinessService"))
+    If $Get(features("noBP")) '= 1 {
+        ; Generate Business process
+        Set sc = $$$ADDSC(sc, ..GenerateBusinessProcess())
     }
 
     If $Get(features("noBS")) '= 1 {
-        ; Generate Business process
-        Set sc = $$$ADDSC(sc, ..GenerateBusinessProcess())
+        ; Generate Business services
+        Set sc = $$$ADDSC(sc, ..IterateOnOperation("GenerateBusinessService"))
 
         ; Generate Proxy service
         Set sc = $$$ADDSC(sc, ..GenerateProxyService())
@@ -79,11 +77,7 @@ Method Generate(ByRef features) As %Status
     Quit sc
 }
 
-Method GenerateBusinessService(
-	path As %String,
-	pathItem As %DynamicObject,
-	method As %String,
-	operation As %DynamicObject) As %Status
+Method GenerateBusinessService(path As %String, pathItem As %DynamicObject, method As %String, operation As %DynamicObject) As %Status
 {
     Set sc = $$$OK
     
@@ -251,11 +245,7 @@ Method GenerateBusinessOperation() As %Status
 	Return sc
 }
 
-Method GenerateMethodExecutor(
-	path As %String,
-	pathItem As %DynamicObject,
-	method As %String,
-	operation As %DynamicObject) As %Status
+Method GenerateMethodExecutor(path As %String, pathItem As %DynamicObject, method As %String, operation As %DynamicObject) As %Status
 {
     Set sc = $$$OK
 

--- a/src/dc/openapi/common/Generator.cls
+++ b/src/dc/openapi/common/Generator.cls
@@ -82,11 +82,7 @@ Method IterateOnResponses(callBackMethod As %String) As %Status [ Private ]
     Quit sc
 }
 
-Method GenerateRequestClass(
-	path As %String,
-	pathItem As %DynamicObject,
-	method As %String,
-	operation As %DynamicObject) As %Status
+Method GenerateRequestClass(path As %String, pathItem As %DynamicObject, method As %String, operation As %DynamicObject) As %Status
 {
     Set sc = $$$OK
     
@@ -153,7 +149,7 @@ Method GenerateRequestClass(
         Set propDef = $$$FindPropertyName(classDef, $$$NormalizePropertyParamName(parameter.in_parameter.name))
         Set:'$IsObject(propDef) propDef = ##class(%Dictionary.PropertyDefinition).%New(classDef.Name _ ":" _ $$$NormalizePropertyParamName(parameter.in_parameter.name))
 
-        Set propDef.Description = parameter.description
+        Set propDef.Description = $REPLACE($ZSTRIP($ZSTRIP(parameter.description, "*", $Char(13)), "<>CW"), $Char(10), $Char(10) _ "/// ")
 
         If 'parameter.%IsDefined("schema") {
             Set propDef.Type = "%String"
@@ -198,10 +194,7 @@ Method GenerateRequestClass(
     Quit sc
 }
 
-ClassMethod CheckAndGenerateOperationId(
-	method As %String,
-	operation As %DynamicObject,
-	path As %String) As %Status
+ClassMethod CheckAndGenerateOperationId(method As %String, operation As %DynamicObject, path As %String) As %Status
 {
     If operation.operationId = "" { ; In order to ease the code generation, we generate an operationId
     
@@ -218,9 +211,7 @@ ClassMethod CheckAndGenerateOperationId(
     Quit $$$OK
 }
 
-ClassMethod GetOperationParameters(
-	pathItem As %DynamicObject,
-	operation As %DynamicObject) As %DynamicArray
+ClassMethod GetOperationParameters(pathItem As %DynamicObject, operation As %DynamicObject) As %DynamicArray
 {
     #dim parameters As %DynamicArray = []
 
@@ -249,7 +240,8 @@ ClassMethod RequestBodyHelper(contentDefinition As %DynamicObject) As %DynamicOb
                 Set type = "%Stream.Object", propertyName = "bodyStream"
             }
         } ElseIf contentTypeItem.schema."$ref"'="" {
-            Set propertyName = $Piece(contentTypeItem.schema."$ref", "/", *)
+            Set propertyName = $zstrip($Piece(contentTypeItem.schema."$ref", "/", *), "*P")
+            Set type = ##class(dc.openapi.common.Utils).GetTempData("model.package") _ "." _ propertyName
         }
 
         If contentTypeItem.schema.type = "array", contentTypeItem.schema.items.%IsDefined("$ref") {
@@ -282,9 +274,7 @@ ClassMethod RequestBodyHelper(contentDefinition As %DynamicObject) As %DynamicOb
     Quit bodyDef
 }
 
-ClassMethod isBodyProperty(
-	propertyName As %String,
-	operation As %DynamicObject) As %Boolean
+ClassMethod isBodyProperty(propertyName As %String, operation As %DynamicObject) As %Boolean
 {
     If '$ISOBJECT(operation.requestBody)||'$IsObject(operation.requestBody.content) Quit $$$NO
 
@@ -293,9 +283,7 @@ ClassMethod isBodyProperty(
     Quit helperObj.%IsDefined(propertyName)
 }
 
-ClassMethod GetContentTypeListForProperty(
-	propertyName,
-	operation As %DynamicObject) As %String
+ClassMethod GetContentTypeListForProperty(propertyName, operation As %DynamicObject) As %String
 {
     If '$ISOBJECT(operation.requestBody)||'$IsObject(operation.requestBody.content) Quit ""
 
@@ -312,11 +300,7 @@ ClassMethod GetContentTypeListForProperty(
     Quit $Extract(list, 2, *)
 }
 
-ClassMethod GetXmlParameters(
-	spec As %DynamicObject,
-	schema As %DynamicObject,
-	Output xmlName,
-	Output xmlItemName)
+ClassMethod GetXmlParameters(spec As %DynamicObject, schema As %DynamicObject, Output xmlName, Output xmlItemName)
 {
     Set (xmlName, xmlItemName) = ""
 


### PR DESCRIPTION
- The new way of generating json introduced an annoying extra newline in Model property comments. DefinitionV3.GenerateProperties() has been changed to remove these again
- For some reason, the comment generation in request generation generated names with underscores and did not apply the same trick to multiline description. Has been added in Generator.GenerateRequestClass()
- Generator.RequestBodyHelper() did not properly set the type for "$ref" items, so these were all generated as "%Stream.Object"
- Important fix for HttpClientGenerator.GenerateResponseClass() to allow for proper generation of List of %String as %DynamicArray is not properly displayed in Visual Trace.
- Als added MAXLEN = "" for the now generated List of %String
- Really small change for incorrect use of nos BS versus noBP flags in ProductionGenerator() 