### PR TITLE
Solution for https://github.com/lscalese/openapi-suite/issues/26.

### DIFF
--- a/src/Nuts/OpenApi.cls
+++ b/src/Nuts/OpenApi.cls
@@ -107,9 +107,9 @@ ClassMethod Generate(packageName As %String, url As %String, modelOnly As %Boole
     // Make sure that the common model is properly referenced!
     // for e.g.  "$ref":"../common/ssi_types.yaml#/components/schemas/DIDDocument"
     set externals =  {
-        "../common/ssi_types.yaml": "Nuts.Api.Common.model"
+        "../common/ssi_types.yaml": "Nuts.Api.Common.model",
+        "../common/error_response.yaml": "Nuts.Api.Common.model.ErrorResponse"
     }
-
     set sc = ##class(dc.openapi.client.Spec).generateApp(packageName, url, .features, externals)
 
     if $$$ISERR(sc)

--- a/src/dc/openapi/client/HttpClientGenerator.cls
+++ b/src/dc/openapi/client/HttpClientGenerator.cls
@@ -452,6 +452,17 @@ Method GenerateResponseClass(path As %String, pathItem As %DynamicObject, method
     Set codeIterator = operation.responses.%GetIterator()
     While codeIterator.%GetNext(.code, .codeItem) {
         
+        if (code = "default") && '$IsObject(codeItem.content) && (codeItem."$ref" '= "") && $ISOBJECT(..spec.externals) {
+            set type = ..spec.externals.%Get(codeItem."$ref")
+
+            if (type '= "") { // Special case of default response:
+                Set k1 = type
+                Set propertyToGen(k1, 0) = "ErrorResponse"
+                Set propertyToGen(k1, 0, "description") = code
+                Continue
+            }
+        }
+
         Continue:'$IsObject(codeItem.content)
         
         Set contentTypeIterator = codeItem.content.%GetIterator()
@@ -560,6 +571,32 @@ Method GenerateLoadFromResponse(path As %String, pathItem As %DynamicObject, met
     Set codeIterator = operation.responses.%GetIterator()
     While codeIterator.%GetNext(.code, .codeItem) {
         
+        if (code = "default") && '$IsObject(codeItem.content) {
+            if (codeItem."$ref" '= "") {
+                if $ISOBJECT(..spec.externals) {
+                    set type = ..spec.externals.%Get(codeItem."$ref")
+
+                    if (type '= "") { // Special case of default response:
+
+                        Do methodDef.Implementation.WriteLine()
+                        Do methodDef.Implementation.WriteLine( $Char(9) _ "#; default")
+                        Do methodDef.Implementation.WriteLine( $Char(9) _ "Set ..ErrorResponse = ##class(" _ type _").%New()")
+                        Do methodDef.Implementation.WriteLine( $Char(9) _ "Set ..status = ..ErrorResponse.%JSONImport(httpResponse.Data)")
+                        Continue
+                    }
+                    else {
+                        Do methodDef.Implementation.WriteLine( $Char(9) _ "#; No code generated for default case with reference to; missing external type for " _ codeItem."$ref")
+                    }
+                }
+                else {
+                    Do methodDef.Implementation.WriteLine( $Char(9) _ "#; No code generated for default case with reference to " _ codeItem."$ref")
+                }
+            }
+            else {
+                Do methodDef.Implementation.WriteLine( $Char(9) _ "#; No code generated for default case")
+            }
+        }
+
         Continue:'$IsObject(codeItem.content)
         
         Set contentTypeIterator = codeItem.content.%GetIterator()
@@ -654,10 +691,8 @@ Method GenerateLoadFromResponse(path As %String, pathItem As %DynamicObject, met
 
             }
         }
-
     }
-
-    Do methodDef.Implementation.WriteLine( $Char(9) _ "Quit sc")
+    Do methodDef.Implementation.WriteLine( $Char(9) _ "Return sc")
 
     Set sc = classDef.%Save()
     Quit sc

--- a/src/dc/openapi/client/HttpClientGenerator.cls
+++ b/src/dc/openapi/client/HttpClientGenerator.cls
@@ -10,7 +10,7 @@ Property packageResponse As %String [ Private ];
 
 Property httpClientClassName As %String [ Private ];
 
-Property genericResponseClassName As %String [ Private ];
+Property genericResponseClassName As %String;
 
 Property superGenericResponse As %String [ InitialExpression = "%RegisteredObject" ];
 

--- a/src/dc/openapi/client/ProductionGenerator.cls
+++ b/src/dc/openapi/client/ProductionGenerator.cls
@@ -9,6 +9,8 @@ Parameter PKGOPERATION = "bo";
 
 Parameter PKGPROCESS = "bp";
 
+Property genericResponseClassName As %String [ Private ];
+
 Property productionClassName As %String [ InitialExpression = "Production" ];
 
 Property tmp As %Binary [ MultiDimensional ];
@@ -34,6 +36,7 @@ Method Generate(ByRef features) As %Status
     Set httpClientGenerator.superRequest = ..superRequest
     Set httpClientGenerator.superModel = "%SerialObject,%JSON.Adaptor,%XML.Adaptor"
     Set httpClientGenerator.superGenericResponse = "Ens.Response"
+    Set ..genericResponseClassName = httpClientGenerator.genericResponseClassName
 
     Set sc = $$$ADDSC(sc, httpClientGenerator.GenerateClient(.features))
 
@@ -278,7 +281,7 @@ Method GenerateHandleRequestMethod() As %Status
     Set methodDef = ##class(%Dictionary.MethodDefinition).%New()
     Set methodDef.Description = "Common request handler"
     Set methodDef.Name = "zzHandleRequest"
-    Set methodDef.FormalSpec = "requestMessage:Ens.Request,name:%String,method:%String,responseMessage:Nuts.Api.Common.responses.GenericResponse"
+    Set methodDef.FormalSpec = "requestMessage:Ens.Request,name:%String,method:%String,responseMessage:" _ ..genericResponseClassName
     Set methodDef.ReturnType = "%Status"
 	Do methodDef.Implementation.WriteLine( $Char(9) _ "set sc = $$$OK, pHttpRequestIn = ##class(%Net.HttpRequest).%New()")
 	Do methodDef.Implementation.WriteLine( $Char(9) _ "$$$QuitOnError(requestMessage.LoadHttpRequestObject(pHttpRequestIn))")


### PR DESCRIPTION
This is a crude solution for solving issue https://github.com/lscalese/openapi-suite/issues/26.
It works in the limited context that I could test this with.
Prerequisite:
- The default response is json
- Openapi spec responses for an endpoint has a default response similar to this one:
```
    "/internal/auth/v1/jwt-grant":{
      "post":{
        "tags":[
          "auth"
        ],
        "summary":"Create a JWT Grant",
        "description":"Create a JWT Grant which can be used in the createAccessToken request in the assertion field\n\nerror returns:\n* 400 - one of the parameters has the wrong format\n",
        "operationId":"createJwtGrant",
        "requestBody":{
          "content":{
            "application/json":{
              "schema":{
                "$ref":"#/components/schemas/CreateJwtGrantRequest"
              }
            }
          },
          "required":true
        },
        "responses":{
          "200":{
            "description":"Successful request. Responds with JWT encoded Bearer Token",
            "content":{
              "application/json":{
                "schema":{
                  "$ref":"#/components/schemas/JwtGrantResponse"
                }
              }
            }
          },
          "default":{
            "$ref":"../common/error_response.yaml"
          }
        }
      }
    },
```
- A mapping for the $ref has been provided in the externals in the call to ##class(dc.openapi.suite.Generate).ProductionClient(), e.g.
```
    set externals =  {
        "../common/ssi_types.yaml": "Nuts.Api.Common.model",
        "../common/error_response.yaml": "Nuts.Api.Common.model.ErrorResponse"
    }

    #; set sc = ##class(dc.openapi.client.Spec).generateApp(packageName, url, .features, externals)
    set sc = ##class(dc.openapi.suite.Generate).ProductionClient(packageName, url, .features, externals)
```
In the Response class, it will now generate a property named ErrorResponse based on the type "Nuts.Api.Common.model.ErrorResponse". Also, in the LoadFromResponse(), the %JSONImport for the ErrorResponse is handled. This looks like as follows:
```
/// default
Property ErrorResponse As Nuts.Api.Common.model.ErrorResponse;

/// http status code = 200 content-type = application/json
/// Successful request. Responds with JWT encoded Bearer Token
Property JwtGrantResponse As Nuts.Api.Auth.model.JwtGrantResponse;

/// Implement operationId : createJwtGrant
/// post /internal/auth/v1/jwt-grant
Method LoadFromResponse(httpResponse As %Net.HttpResponse, caller As %String = "") As %Status
{
	Set sc = $$$OK
	Do ##super(httpResponse, caller)
	If $$$LOWER($Piece(httpResponse.ContentType,";",1))="application/json",httpResponse.StatusCode = "200" {
		Set ..JwtGrantResponse = ##class(Nuts.Api.Auth.model.JwtGrantResponse).%New()
		Set ..status = ..JwtGrantResponse.%JSONImport(httpResponse.Data)
		Return sc
	}

	#; default
	Set ..ErrorResponse = ##class(Nuts.Api.Common.model.ErrorResponse).%New()
	Set ..status = ..ErrorResponse.%JSONImport(httpResponse.Data)
	Return sc
}

```
